### PR TITLE
Fix crash in lastupdate() method

### DIFF
--- a/rrdtoolmodule.c
+++ b/rrdtoolmodule.c
@@ -880,9 +880,19 @@ _rrdtool_lastupdate(PyObject *self, PyObject *args)
         PyDict_SetItemString(ret, "ds", ds_dict);
 
         for (i = 0; i < ds_cnt; i++) {
-            PyDict_SetItemString(ds_dict,
-                ds_names[i],
-                PyRRD_Int_FromString(last_ds[i], NULL, 10));
+            PyObject* val = Py_None;
+
+            double num;
+            if (sscanf(last_ds[i], "%lf", &num) == 1) {
+                val = PyFloat_FromDouble(num);
+            }
+
+            if (!val)
+                return NULL;
+
+            PyDict_SetItemString(ds_dict, ds_names[i], val);
+            Py_DECREF(val);
+
             free(last_ds[i]);
             free(ds_names[i]);
         }


### PR DESCRIPTION
When a RRD database contains floating point values, the
PyRRD_Int_FromString function returns NULL, which will then be tried
to be put into a dictionary.
This operation fails as PyDict_SetItemString does not handle NULL
and the program crashes with SEGV.

This patch parses the value as a floating point number
and will add that instead. If the value could not be parsed,
None will be added instead.

Signed-off-by: Michael Tremer <michael.tremer@ipfire.org>