### PR TITLE
Use PyUnicode_AsUTF8 to fix memory leak

### DIFF
--- a/rrdtoolmodule.c
+++ b/rrdtoolmodule.c
@@ -31,7 +31,7 @@
 #define HAVE_PY3K
 #define PyRRD_String_Check(x)      PyUnicode_Check(x)
 #define PyRRD_String_FromString(x) PyUnicode_FromString(x)
-#define PyRRD_String_AS_STRING(x)  PyBytes_AsString(PyUnicode_AsUTF8String(o))
+#define PyRRD_String_AS_STRING(x)  PyUnicode_AsUTF8(x)
 #define PyRRD_String_FromStringAndSize(x, y)  PyBytes_FromStringAndSize(x, y)
 #define PyRRD_Int_FromLong(x)      PyLong_FromLong(x)
 #define PyRRD_Int_FromString(x, y, z)  PyLong_FromString(x,y,z)


### PR DESCRIPTION
In Python3, I was experiencing a huge memory leak using this module. From 350mb to over 8GB in just a few hours. (Continuous polling of many interfaces). Python2 didn't have an issue. I tracked it down to this:

PyBytes_AsString(PyUnicode_AsUTF8String(o))

The PyUnicode_AsUTF8String allocates a new reference [https://docs.python.org/3.4/c-api/unicode.html#utf-8-codecs]
As such, it would need a PyDECREF afterwards. I attempted the fix with something like this first:

    PyObject *temp_bytes;
    char *ret;
    temp_bytes = PyUnicode_AsUTF8String(o);
    ret = PyBytes_AsString(temp_bytes);
    Py_DECREF(temp_bytes);

That fixed the memory leak, however, then numeric arguments threw an error for some reason. (-s 60 for example, the 60 was rejected by the rrd_create function).

In looking around [https://docs.python.org/3.4/c-api/unicode.html#utf-8-codecs] more, python 3.3 added this function: PyUnicode_AsUTF8. This seems to do everything in one step now, and it mentions that no deallocation of buffer is required to use it.

After making that simple change (replace PyBytes_AsString(PyUnicode_AsUTF8String(o)) with PyUnicode_AsUTF8(x)), I now have no memory leak problems.

I've not programmed in C in a long time, and never using the Python C API, so I may be missing something. The change works for me with both the create and update functions, though. No more memory leak!