### PR TITLE
Add missing header file to the list of sources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 
 def main():
     module = Extension('rrdtool',
-                       sources=['rrdtoolmodule.c'],
+                       sources=['rrdtoolmodule.h', 'rrdtoolmodule.c'],
                        include_dirs=['/usr/local/include'],
                        library_dirs=['/usr/local/lib'],
                        libraries=['rrd'])


### PR DESCRIPTION
The rrdtool-0.1.7 setup from PyPI has been failing due to this missing header.