### PR TITLE
Fix build for cygwin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,14 @@ def compile_extensions(macros, compat=False):
     import distutils.ccompiler
     import tempfile
     import shutil
+    import platform
 
     from textwrap import dedent
 
     # common vars
     libraries = ['rrd']
+    if platform.system().upper().startswith('CYGWIN'):
+        libraries.extend(['cairo', 'pango-1.0', 'pangocairo-1.0', 'png', 'glib-2.0', 'gobject-2.0'])
     include_dirs = [package_dir, '/usr/local/include']
     library_dirs = ['/usr/local/lib']
     compiler_args = dict(


### PR DESCRIPTION
In cygwin I've got the following errors during setup:
```
/usr/local/lib/librrd.a(librrd_la-rrd_graph.o): In function 'graph_cairo_setup':
/home/.../Downloads/rrdtool/rrdtool-1.7.2/src/rrd_graph.c:4327: undefined reference to 'cairo_surface_destroy'
/usr/local/lib/librrd.a(librrd_la-rrd_graph.o): In function 'bad_format_check':
/home/.../Downloads/rrdtool/rrdtool-1.7.2/src/rrd_graph.c:5570: undefined reference to 'g_regex_new'
...
```

So to prevent this I've added required libraries into setup script for cygwin platform.

rrdtool was built like this:
```
export LDFLAGS=-Wl,--no-undefined
export PYTHON=/bin/python3.6
./configure --disable-mmap --prefix=/usr/local --disable-tcl --disable-perl --disable-ruby
make
make install
```