### PR TITLE
Correct custom fetch callback examples

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -254,7 +254,7 @@ The function calls are converted to appropriate values and mapped to their librr
       ]
 
       def my_callback(filename, cf, start, end, step):
-          itemcount = (end - start) / step
+          itemcount = math.ceil((end - start) / step)
           return {
               'start': start,
               'step': 300,
@@ -265,8 +265,8 @@ The function calls are converted to appropriate values and mapped to their librr
               }
           }
 
-      rrdtool.register_fetch_cb(my_callable)
-      rrdtool.graphv(**graphv_args)
+      rrdtool.register_fetch_cb(my_callback)
+      rrdtool.graphv(*graphv_args)
 
       # also works with callable objects
       class MyCallable(object):
@@ -276,7 +276,7 @@ The function calls are converted to appropriate values and mapped to their librr
 
       cb = MyCallable()
       rrdtool.register_fetch_cb(cb)  # overwrite callback
-      rrdtool.graphv(**graphv_args)
+      rrdtool.graphv(*graphv_args)
 
    .. note:: This function uses Python long integers on Python 2.x and 3.x to minimize compatibility code requirements (Python 3 has long integers as its default int anyway).
 


### PR DESCRIPTION
The callback was previously erroring out because of this error:
```py
  File "test.py", line 33, in my_callback
    'a': [math.sin(x / 200) for x in range(0, itemcount)],
                                     ^^^^^^^^^^^^^^^^^^^
TypeError: 'float' object cannot be interpreted as an integer
```
Unfortunately this is only visible if one wraps the function in a manual error handler (it just returns `NULL` in case it errors, apparently).
There was also a small typo with the callback name and the way the graphv args were passed.